### PR TITLE
Fixes public-read ACL issues

### DIFF
--- a/fields/field.s3upload.php
+++ b/fields/field.s3upload.php
@@ -375,7 +375,7 @@ class FieldS3Upload extends FieldUpload
 
         ## Upload the new file
         $options = array(
-            'Acl' => 'public-read',
+            'ACL' => 'public-read',
             'ContentType' => $data['type']
         );
 


### PR DESCRIPTION
According to this document http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-s3.html it says the key needs to be in caps. When I changed it, I was able to upload with "public" permissions already set on the objects.