### PR TITLE
s3-bucket-url-update

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -14,6 +14,9 @@
         </author>
     </authors>
     <releases>
+	    <release version="0.9.3" date="2019-05-24" min="2.3.1" max="2.x.x">
+            * S3 URL updated to use bucket subdomain rather than sub folder. New requirement from AWS.
+        </release>
         <release version="0.9.2" date="2018-04-09" min="2.3.1" max="2.x.x">
             * Remove use of `/e` modifier for PHP 7 compatibility
         </release>

--- a/fields/field.s3upload.php
+++ b/fields/field.s3upload.php
@@ -71,7 +71,7 @@ class FieldS3Upload extends FieldUpload
         $protocol = ($this->get('ssl_option') == true ? 'https://' : 'http://');
 
         if ($this->get('cname') == '') {
-            $url = $protocol . "s3.amazonaws.com/" . $this->get('bucket') . "/" . $file;
+            $url = $protocol . $this->get('bucket') . ".s3.amazonaws.com/" . $file;
         }
         else {
             $url = $protocol . $this->get('cname') . "/" . $file;


### PR DESCRIPTION
S3 URL updated to use bucket subdomain rather than sub folder. This is a new requirement from AWS.